### PR TITLE
Rewrite all table scans to use federated table name

### DIFF
--- a/sources/sql/src/lib.rs
+++ b/sources/sql/src/lib.rs
@@ -95,7 +95,7 @@ fn rewrite_table_scans(plan: &LogicalPlan) -> Result<LogicalPlan> {
         if let LogicalPlan::TableScan(table_scan) = plan {
             let mut new_table_scan = table_scan.clone();
             new_table_scan.table_name = TableReference::from("eth.blocks");
-            return Ok(LogicalPlan::TableScan(table_scan.clone())); // SILLY
+            return Ok(LogicalPlan::TableScan(new_table_scan.clone())); // SILLY
         } else {
             return Ok(plan.clone());
         }

--- a/sources/sql/src/schema.rs
+++ b/sources/sql/src/schema.rs
@@ -136,6 +136,10 @@ impl SQLTableSource {
             schema,
         })
     }
+
+    pub fn table_name(&self) -> &str {
+        self.table_name.as_str()
+    }
 }
 
 impl FederatedTableSource for SQLTableSource {


### PR DESCRIPTION
Before federating the plan, rewrite all TableScans in the plan to use the table name in the remote source, with a subquery alias back to the original name. This allows the table names in the source, and the table names in DataFusion to be different.

i.e.

if my table is named "transactions" in the source, but registered as "tx" in DataFusion:

Query from DataFusion:
`SELECT number FROM tx LIMIT 10`

Turns into this federated query:
`SELECT "tx"."number" FROM "transactions" AS "tx" LIMIT 10`