### PR TITLE
Rewrite subquery table scans to point to remote table

### DIFF
--- a/sources/sql/Cargo.toml
+++ b/sources/sql/Cargo.toml
@@ -22,6 +22,7 @@ datafusion-federation.path = "../../datafusion-federation"
 # derive_builder = "0.13.0"
 futures = "0.3.30"
 tokio = "1.35.1"
+tracing = "0.1.40"
 
 [features]
 connectorx = ["dep:connectorx"]

--- a/sources/sql/src/lib.rs
+++ b/sources/sql/src/lib.rs
@@ -76,6 +76,7 @@ impl SQLFederationAnalyzerRule {
 
 impl AnalyzerRule for SQLFederationAnalyzerRule {
     fn analyze(&self, plan: LogicalPlan, _config: &ConfigOptions) -> Result<LogicalPlan> {
+        tracing::info!("SQLFederationAnalyzerRule: plan={plan:?}");
         // Find all table scans, recover the SQLTableSource, find the remote table name and replace the name of the TableScan table.
         let plan = rewrite_table_scans(&plan)?;
 

--- a/sources/sql/src/lib.rs
+++ b/sources/sql/src/lib.rs
@@ -94,6 +94,7 @@ impl AnalyzerRule for SQLFederationAnalyzerRule {
 
 /// Rewrite table scans to use the original federated table name.
 fn rewrite_table_scans(plan: &LogicalPlan) -> Result<LogicalPlan> {
+    tracing::trace!("rewrite_table_scans: plan={plan:?}");
     if plan.inputs().is_empty() {
         if let LogicalPlan::TableScan(table_scan) = plan {
             let original_table_name = table_scan.table_name.clone();
@@ -128,6 +129,7 @@ fn rewrite_table_scans(plan: &LogicalPlan) -> Result<LogicalPlan> {
 
     let mut new_expressions = vec![];
     for expression in plan.expressions() {
+        tracing::trace!("rewrite_table_scans: expression={expression:?}");
         new_expressions.push(rewrite_table_scans_in_subqueries(expression)?);
     }
 

--- a/sources/sql/src/lib.rs
+++ b/sources/sql/src/lib.rs
@@ -7,7 +7,7 @@ use datafusion::{
     config::ConfigOptions,
     error::Result,
     execution::{context::SessionState, TaskContext},
-    logical_expr::{Extension, LogicalPlan, SubqueryAlias},
+    logical_expr::{Expr, Extension, LogicalPlan, Subquery, SubqueryAlias},
     optimizer::analyzer::{Analyzer, AnalyzerRule},
     physical_expr::EquivalenceProperties,
     physical_plan::{
@@ -126,15 +126,33 @@ fn rewrite_table_scans(plan: &LogicalPlan) -> Result<LogicalPlan> {
         }
     }
 
+    let mut new_expressions = vec![];
+    for expression in plan.expressions() {
+        new_expressions.push(rewrite_table_scans_in_subqueries(expression)?);
+    }
+
     let rewritten_inputs = plan
         .inputs()
         .into_iter()
         .map(rewrite_table_scans)
         .collect::<Result<Vec<_>>>()?;
 
-    let new_plan = plan.with_new_exprs(plan.expressions(), rewritten_inputs)?;
+    let new_plan = plan.with_new_exprs(new_expressions, rewritten_inputs)?;
 
     Ok(new_plan)
+}
+
+fn rewrite_table_scans_in_subqueries(expr: Expr) -> Result<Expr> {
+    match expr {
+        Expr::ScalarSubquery(subquery) => {
+            let new_subquery = rewrite_table_scans(&subquery.subquery)?;
+            Ok(Expr::ScalarSubquery(Subquery {
+                subquery: Arc::new(new_subquery),
+                outer_ref_columns: subquery.outer_ref_columns,
+            }))
+        }
+        _ => Ok(expr),
+    }
 }
 
 struct SQLFederationPlanner {

--- a/sources/sql/src/lib.rs
+++ b/sources/sql/src/lib.rs
@@ -151,7 +151,10 @@ fn rewrite_table_scans_in_subqueries(expr: Expr) -> Result<Expr> {
                 outer_ref_columns: subquery.outer_ref_columns,
             }))
         }
-        _ => Ok(expr),
+        _ => {
+            tracing::debug!("rewrite_table_scans_in_subqueries: no match for expr={expr:?}",);
+            Ok(expr)
+        }
     }
 }
 


### PR DESCRIPTION
Will be able to support queries like:

`SELECT number FROM blocks WHERE number = (SELECT MAX(number) FROM blocks)`

And have the reference `blocks` be expanded to the correct table reference on the remote query engine (which might be different from `blocks`)